### PR TITLE
Make react and react-dom as injectable dependencies. So, we can reduce the bundle size for React hosts

### DIFF
--- a/apps/react/public/index.html
+++ b/apps/react/public/index.html
@@ -6,11 +6,13 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <script  src="/cdn/movie-widgets/index.js"></script>
         <title>React app</title>
-        <script>
+        <!-- <script>
             window.MovieWidgets.initialize({
                 theme: document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"
+            },{
+
             });
-        </script>
+        </script> -->
     </head>
     <body>
         <div id="root"></div>

--- a/apps/react/src/App.tsx
+++ b/apps/react/src/App.tsx
@@ -3,7 +3,6 @@ import { Layout } from "./Layout.tsx";
 import { MainPage } from "./MainPage.tsx";
 import { StorePage } from "./StorePage.tsx";
 
-
 export function App() {
     return (
         <Routes>

--- a/apps/react/src/index.tsx
+++ b/apps/react/src/index.tsx
@@ -4,7 +4,18 @@ import { BrowserRouter } from "react-router-dom";
 import { App } from "./App.tsx";
 import "./index.css";
 
+import { createPortal } from "react-dom";
+
 const root = createRoot(document.getElementById("root")!);
+
+window.MovieWidgets?.initialize({
+    theme: document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"
+}, {
+    createRoot: createRoot,
+    createPortal: createPortal
+});
+
+debugger;
 
 root.render(
     <StrictMode>

--- a/apps/react/widgets/widgets-manager.d.ts
+++ b/apps/react/widgets/widgets-manager.d.ts
@@ -3,8 +3,13 @@ interface AppSettings {
     theme: "light" | "dark" | "system";
 }
 
+interface IRenderingConfig {
+    createRoot: typeof CreateRootType;
+    createPortal: typeof CreatePortalType;
+}
+
 interface IWidgetsManager<T> {
-    initialize: (settings?: T) => void;
+    initialize: (settings?: T, renderingConfig?: IRenderingConfig) => void;
     update: (settings: Partial<T>) => void;
     appSettings?: T | null;
 }

--- a/widgets/src/r2wc/RndererModule.ts
+++ b/widgets/src/r2wc/RndererModule.ts
@@ -1,0 +1,36 @@
+import type { createPortal as CreatePortalType } from "react-dom";
+import type { createRoot as CreateRootType, Root } from "react-dom/client";
+
+export interface IRenderingConfig {
+    createRoot: typeof CreateRootType;
+    createPortal: typeof CreatePortalType;
+}
+
+
+export class RndererModule {
+    static #root: Root | null = null;
+    static #createPortal: typeof CreatePortalType | null = null;
+
+    static get root(): Root {
+        if (!this.#root) {
+            throw new Error("Root has not been initialized yet.");
+        }
+
+        return this.#root;
+    }
+
+    static get createPortal(): typeof CreatePortalType {
+        if (!this.#createPortal) {
+            throw new Error("createPortal has not been initialized yet.");
+        }
+
+        return this.#createPortal;
+    }
+
+    static init({ createRoot, createPortal }: IRenderingConfig) {
+        this.#createPortal = createPortal;
+
+        const rootContainer = document.createElement("div");
+        this.#root = createRoot(rootContainer);
+    }
+}

--- a/widgets/src/r2wc/WebComponentHTMLElement.tsx
+++ b/widgets/src/r2wc/WebComponentHTMLElement.tsx
@@ -1,7 +1,7 @@
 import type { ReactPortal } from "react";
-import { createPortal } from "react-dom";
 import { Observable } from "./Observable.ts";
 import { PropsProvider } from "./PropsProvider.tsx";
+import { RndererModule } from "./RndererModule.ts";
 import { type Map, getMapConvert, getMapName } from "./utils.ts";
 import { notifyWidgetMountState } from "./WidgetsManager.tsx";
 
@@ -25,7 +25,7 @@ export class WebComponentHTMLElementBase extends HTMLElement {
     }
 
     connectedCallback() {
-        this.#portal = createPortal(this.renderReactComponent(), this);
+        this.#portal = RndererModule.createPortal(this.renderReactComponent(), this);
 
         notifyWidgetMountState(this, "mounted");
     }

--- a/widgets/src/web-components/widgets.ts
+++ b/widgets/src/web-components/widgets.ts
@@ -23,4 +23,5 @@ declare global {
 window.MovieWidgets = new WidgetsManager({
     elements: [MovieDetailsElement, MoviePopUpElement, MovieFinderElement, SelectedMovieElement, TicketElement],
     contextProvider: AppContextProvider
+
 });

--- a/widgets/tsup.build.ts
+++ b/widgets/tsup.build.ts
@@ -3,6 +3,7 @@ import { defineBuildConfig } from "@workleap/tsup-configs";
 export default defineBuildConfig({
     entry: ["src/index.ts"],
     outDir: "dist",
+    //noExternal: [/^(?!react-dom\/client$|react-dom$).*/],
     noExternal: [/.*/],
     minify: true,
     treeshake: true


### PR DESCRIPTION
Two issues:
- Unknown exception at rendering time. 
- But more importantly, our DS, or any underlying package that may have used `render` or `createPortal` still need these libraries and we cannot get rid of them easily.