### PR TITLE
resolve data binding for not defined elements

### DIFF
--- a/.changeset/nervous-mails-approve.md
+++ b/.changeset/nervous-mails-approve.md
@@ -1,0 +1,5 @@
+---
+"@workleap/r2wc": patch
+---
+
+Fix a bug: Resolve web elements "data" properties even if they have been set sooner than the element gets defined.

--- a/samples/react/public/index.html
+++ b/samples/react/public/index.html
@@ -5,8 +5,6 @@
         <link href="favicon.png" rel="icon">
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>React app</title>
-        <link rel="modulepreload" href="/cdn/movie-widgets/index.js" />
-        <script type="module" src="/cdn/movie-widgets/index.js"></script>
         <script type="module" src="index.js" blocking="render" async="false"></script>
     </head>
     <body>

--- a/samples/react/public/index.js
+++ b/samples/react/public/index.js
@@ -1,5 +1,20 @@
-import { MovieWidgets } from "/cdn/movie-widgets/index.js";
 
-MovieWidgets.initialize({
-    theme: document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"
-});
+const head = document.getElementsByTagName("head")[0];
+
+const link = document.createElement("link");
+link.rel = "modulepreload";
+link.href = "/cdn/movie-widgets/index.js";
+
+head.insertBefore(link, head.firstChild);
+
+const script = document.createElement("script");
+script.src = "/cdn/movie-widgets/index.js";
+script.type = "module";
+script.onload = () => {
+    window.MovieWidgets.initialize({
+        theme: document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"
+    });
+};
+
+head.appendChild(script);
+

--- a/samples/react/src/Layout.tsx
+++ b/samples/react/src/Layout.tsx
@@ -1,7 +1,7 @@
 import { Button, Div, Flex } from "@workleap/orbiter-ui";
 import { Link, Outlet } from "react-router-dom";
 
-import { MovieFinder, SelectedMovie } from "../../widgets/movie-widgets/dist/react/index.js";
+import { MovieFinder, SelectedMovie } from "@samples/movie-widgets/react";
 
 import { AppContextProvider, useAppContext } from "./AppContext.tsx";
 

--- a/samples/react/src/MainPage.tsx
+++ b/samples/react/src/MainPage.tsx
@@ -1,6 +1,6 @@
+import { MovieDetails, MoviePopup, SelectedMovie, Ticket } from "@samples/movie-widgets/react";
 import { Flex } from "@workleap/orbiter-ui";
 import { useState } from "react";
-import { MovieDetails, MoviePopup, SelectedMovie, Ticket } from "../../widgets/movie-widgets/dist/react/index.js";
 
 export function MainPage() {
     const [boughtTickets, setBoughtTickets] = useState<{ key: string; count:number; title: string }[]>([]);

--- a/samples/react/src/StorePage.tsx
+++ b/samples/react/src/StorePage.tsx
@@ -1,6 +1,6 @@
+import { MovieDetails, SelectedMovie } from "@samples/movie-widgets/react";
 import { Checkbox } from "@workleap/orbiter-ui";
 import { useState } from "react";
-import { MovieDetails, SelectedMovie } from "../../widgets/movie-widgets/dist/react/index.js";
 
 export function StorePage() {
     const [showRanking, setShowRanking] = useState(false);


### PR DESCRIPTION
Fix the situation where widget's `data` property has been set before the scripts are being loaded.
In this situation, the getter and setter functions were being masked by the set data and made the web component not functional.

With this fix, this issue has been addressed.