### PR TITLE
Make WidgetsManager extensible

### DIFF
--- a/.changeset/weak-experts-hide.md
+++ b/.changeset/weak-experts-hide.md
@@ -2,4 +2,5 @@
 "@workleap/r2wc": minor
 ---
 
-Add `contextProviderProps` and `extends` method to `WidgetsManager` to make it more flexible and being able to expose functions outside of the Widgets.
+- Add `contextProviderProps` and `extends` method to `WidgetsManager` to make it more flexible and being able to expose functions outside of the Widgets.
+- Rename the `appSettings` to `settings` in `IWidgetsManager` interface. 

--- a/.changeset/weak-experts-hide.md
+++ b/.changeset/weak-experts-hide.md
@@ -1,0 +1,5 @@
+---
+"@workleap/r2wc": minor
+---
+
+Add `contextProviderProps` and `extends` method to `WidgetsManager` to make it more flexible and being able to expose functions outside of the Widgets.

--- a/packages/r2wc/src/WidgetsManager.tsx
+++ b/packages/r2wc/src/WidgetsManager.tsx
@@ -61,7 +61,7 @@ export function notifyWidgetMountState(element: WebComponentHTMLElementBase, eve
 export interface IWidgetsManager<T> {
     initialize: (settings?: T) => void;
     update: (settings: Partial<T>) => void;
-    appSettings?: T | null;
+    settings?: T | null;
     unmount: () => void;
 }
 
@@ -73,15 +73,15 @@ interface ConstructionOptions<T> {
     syncRendering?: boolean;
 }
 
-export class WidgetsManager<AppSettings = unknown> implements IWidgetsManager<AppSettings> {
-    #contextProps: Observable<AppSettings> = new Observable<AppSettings>();
-    #initialContextProps: Partial<AppSettings> | undefined;
+export class WidgetsManager<WidgetsSettings = unknown> implements IWidgetsManager<WidgetsSettings> {
+    #contextProps: Observable<WidgetsSettings> = new Observable<WidgetsSettings>();
+    #initialContextProps: Partial<WidgetsSettings> | undefined;
     static #instanciated = false;
     #syncRendering: boolean;
 
     constructor (
-        config: ConstructionOptions<AppSettings>) {
-        const { elements, contextProvider, contextProviderProps, ignoreLoadingCss = false, syncRendering = false } = config;
+        settings: ConstructionOptions<WidgetsSettings>) {
+        const { elements, contextProvider, contextProviderProps, ignoreLoadingCss = false, syncRendering = false } = settings;
 
         if (WidgetsManager.#instanciated) {throw new Error("You cannot create multiple instances of WidgetsManager");}
 
@@ -97,10 +97,10 @@ export class WidgetsManager<AppSettings = unknown> implements IWidgetsManager<Ap
         };
     }
 
-    extends<ExtendedProps extends object>(data: ExtendedProps): IWidgetsManager<AppSettings> & ExtendedProps {
+    extends<ExtendedProps extends object>(data: ExtendedProps): IWidgetsManager<WidgetsSettings> & ExtendedProps {
         Object.assign(this, data);
 
-        return this as unknown as IWidgetsManager<AppSettings> & ExtendedProps;
+        return this as unknown as IWidgetsManager<WidgetsSettings> & ExtendedProps;
     }
 
     #countOccurrences(mainString: string, subString: string) {
@@ -126,13 +126,13 @@ export class WidgetsManager<AppSettings = unknown> implements IWidgetsManager<Ap
         document.head.appendChild(link);
     }
 
-    #renderContextWithProps(ContextProvider: ComponentType<AppSettings | (AppSettings & { children?: React.ReactNode })>, children: React.ReactNode | undefined) {
+    #renderContextWithProps(ContextProvider: ComponentType<WidgetsSettings | (WidgetsSettings & { children?: React.ReactNode })>, children: React.ReactNode | undefined) {
         return <PropsProvider Component={ContextProvider} observable={this.#contextProps}>
             {children}
         </PropsProvider>;
     }
 
-    #renderWidgets(contextProvider: ComponentType<AppSettings | (AppSettings & { children?: React.ReactNode })> | undefined) {
+    #renderWidgets(contextProvider: ComponentType<WidgetsSettings | (WidgetsSettings & { children?: React.ReactNode })> | undefined) {
         const portals = activeWidgets.map(item =>
             //this unique key is needed to avoid loosing the state of the component when some adjacent elements are removed.
             <Fragment key={item.key}>
@@ -156,19 +156,19 @@ export class WidgetsManager<AppSettings = unknown> implements IWidgetsManager<Ap
         initialized = false;
     }
 
-    initialize(settings?: AppSettings) {
-        this.#contextProps.value = { ...this.#initialContextProps, ...(settings ?? {} as AppSettings) };
+    initialize(settings?: WidgetsSettings) {
+        this.#contextProps.value = { ...this.#initialContextProps, ...(settings ?? {} as WidgetsSettings) };
         initialized = true;
         render();
     }
 
-    update(settings: Partial<AppSettings>) {
+    update(settings: Partial<WidgetsSettings>) {
         this.#contextProps.value = {
-            ...this.#contextProps.value ?? {} as AppSettings,
+            ...this.#contextProps.value ?? {} as WidgetsSettings,
             ...settings
         };
     }
-    get appSettings() {
+    get settings() {
         return this.#contextProps.value;
     }
 }

--- a/packages/r2wc/src/index.ts
+++ b/packages/r2wc/src/index.ts
@@ -1,3 +1,3 @@
 export { type AttributeEventMap } from "./utils.ts";
 export { WebComponentHTMLElement, WebComponentHTMLElementBase } from "./WebComponentHTMLElement.tsx";
-export { WidgetsManager } from "./WidgetsManager.tsx";
+export { WidgetsManager, type IWidgetsManager } from "./WidgetsManager.tsx";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,11 +156,11 @@ importers:
         specifier: ^2.8.4
         version: 2.8.4(@hopper-ui/styled-system@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria-components@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@hopper-ui/tokens':
-        specifier: 4.4.0
-        version: 4.4.0
+        specifier: 4.4.1
+        version: 4.4.1
       '@workleap/orbiter-ui':
-        specifier: 5.5.0
-        version: 5.5.0(@hopper-ui/components@1.3.31(@hopper-ui/styled-system@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria-components@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria@3.35.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@hopper-ui/styled-system@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria-components@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 5.6.6
+        version: 5.6.6(@hopper-ui/components@1.3.31(@hopper-ui/styled-system@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria-components@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria@3.35.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@hopper-ui/styled-system@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria-components@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@workleap/r2wc':
         specifier: workspace:*
         version: link:../../../packages/r2wc
@@ -172,29 +172,29 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/react':
-        specifier: 18.3.11
-        version: 18.3.11
+        specifier: 18.3.12
+        version: 18.3.12
       '@types/react-dom':
         specifier: 18.3.1
         version: 18.3.1
       '@workleap/eslint-plugin':
-        specifier: 3.2.2
-        version: 3.2.2(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
+        specifier: 3.2.3
+        version: 3.2.3(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
       '@workleap/tsup-configs':
         specifier: 3.0.6
-        version: 3.0.6(tsup@8.3.0(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0))(typescript@5.6.3)
+        version: 3.0.6(tsup@8.3.5(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.7.2)(yaml@2.6.0))(typescript@5.7.2)
       '@workleap/typescript-configs':
         specifier: 3.0.2
-        version: 3.0.2(typescript@5.6.3)
+        version: 3.0.2(typescript@5.7.2)
       eslint:
         specifier: 8.57.1
         version: 8.57.1
       tsup:
-        specifier: 8.3.0
-        version: 8.3.0(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0)
+        specifier: 8.3.5
+        version: 8.3.5(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.7.2)(yaml@2.6.0)
       typescript:
-        specifier: 5.6.3
-        version: 5.6.3
+        specifier: 5.7.2
+        version: 5.7.2
 
 packages:
 
@@ -820,34 +820,16 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
-  '@esbuild/aix-ppc64@0.23.1':
-    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.24.0':
     resolution: {integrity: sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.23.1':
-    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.24.0':
     resolution: {integrity: sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.23.1':
-    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.24.0':
@@ -856,34 +838,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.23.1':
-    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.24.0':
     resolution: {integrity: sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.23.1':
-    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.24.0':
     resolution: {integrity: sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.23.1':
-    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.24.0':
@@ -892,22 +856,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.23.1':
-    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.24.0':
     resolution: {integrity: sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.23.1':
-    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.24.0':
@@ -916,22 +868,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.23.1':
-    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.24.0':
     resolution: {integrity: sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.23.1':
-    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.24.0':
@@ -940,22 +880,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.23.1':
-    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.24.0':
     resolution: {integrity: sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.23.1':
-    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.24.0':
@@ -964,22 +892,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.23.1':
-    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.24.0':
     resolution: {integrity: sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.23.1':
-    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.24.0':
@@ -988,22 +904,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.23.1':
-    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.24.0':
     resolution: {integrity: sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.23.1':
-    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.24.0':
@@ -1012,23 +916,11 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.23.1':
-    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.24.0':
     resolution: {integrity: sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
-
-  '@esbuild/netbsd-x64@0.23.1':
-    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
 
   '@esbuild/netbsd-x64@0.24.0':
     resolution: {integrity: sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==}
@@ -1036,22 +928,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.23.1':
-    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.24.0':
     resolution: {integrity: sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.23.1':
-    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.24.0':
@@ -1060,23 +940,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.23.1':
-    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.24.0':
     resolution: {integrity: sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.23.1':
-    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.24.0':
     resolution: {integrity: sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==}
@@ -1084,22 +952,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.23.1':
-    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.24.0':
     resolution: {integrity: sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.23.1':
-    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.24.0':
@@ -1164,8 +1020,8 @@ packages:
       react: ^18
       react-dom: ^18
 
-  '@hopper-ui/tokens@4.4.0':
-    resolution: {integrity: sha512-cM4wxM+u2bWwbbg5Z2Y2MA6c998pcrwr+mpbFPbwoMD2LLfKkCtQtbxUNjQmLSYDMXvhALU5ToI87V6sTgbkyg==}
+  '@hopper-ui/tokens@4.4.1':
+    resolution: {integrity: sha512-b4enyXJ7ThAvxCBDfM5tdf7xOEJldejukhrXfu/ib3v22mgmDge+v9tnbTJiMWWsjfzAhH/kiIODxLk2f5o7HA==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -1344,6 +1200,9 @@ packages:
 
   '@popperjs/core@2.11.2':
     resolution: {integrity: sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==}
+
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@react-aria/accordion@3.0.0-alpha.35':
     resolution: {integrity: sha512-eZcsHJDVDNIZ2XUmJynHScRv1YAF/+fj5T0zoGdyEPImIIxJLROupQ75uwarAI5btGSR2TFeqYRmRXJrVuxgoA==}
@@ -2344,9 +2203,6 @@ packages:
   '@types/react-dom@18.3.1':
     resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
 
-  '@types/react@18.3.11':
-    resolution: {integrity: sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==}
-
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
 
@@ -2598,6 +2454,15 @@ packages:
     peerDependencies:
       react: '*'
       react-dom: '*'
+
+  '@workleap/orbiter-ui@5.6.6':
+    resolution: {integrity: sha512-zAT8uiDL4G0znWMjKmjGM4pExMVBUcOMLC4WDrkI8Td2pOwAzsk3SH/MfxS97O3061emTFGso8zTtqw0x62zQg==}
+    peerDependencies:
+      '@hopper-ui/components': '*'
+      '@hopper-ui/styled-system': '*'
+      react: ^18.0.0
+      react-aria-components: '*'
+      react-dom: ^18.0.0
 
   '@workleap/swc-configs@2.2.3':
     resolution: {integrity: sha512-zrDsorHKxZY4/DlahkWucNm7kH9xAWxsq0WAWAKcCeFiYUX2TqZT+FNKn3Rl2a//MJgEQJlcYD0VaUIZP3J17A==}
@@ -3386,11 +3251,6 @@ packages:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.23.1:
-    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   esbuild@0.24.0:
     resolution: {integrity: sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==}
     engines: {node: '>=18'}
@@ -3605,10 +3465,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
-
   express@4.21.0:
     resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
     engines: {node: '>= 0.10.0'}
@@ -3746,10 +3602,6 @@ packages:
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
-
-  get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
 
   get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
@@ -3902,10 +3754,6 @@ packages:
 
   human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
-
-  human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
 
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
@@ -4134,10 +3982,6 @@ packages:
   is-shared-array-buffer@1.0.3:
     resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
     engines: {node: '>= 0.4'}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
 
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -4528,10 +4372,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
-
   mini-css-extract-plugin@2.9.2:
     resolution: {integrity: sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==}
     engines: {node: '>= 12.13.0'}
@@ -4646,10 +4486,6 @@ packages:
     resolution: {integrity: sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
-
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -4698,10 +4534,6 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
 
   open@10.1.0:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
@@ -4996,6 +4828,9 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -5267,9 +5102,6 @@ packages:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
     engines: {node: '>= 0.4'}
 
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5408,10 +5240,6 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-
-  strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -5589,25 +5417,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsup@8.3.0:
-    resolution: {integrity: sha512-ALscEeyS03IomcuNdFdc0YWGVIkwH1Ws7nfTbAPuoILvEV2hpGQAY72LIOjglGo4ShWpZfpBqP/jpQVCzqYQag==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-
   tsup@8.3.5:
     resolution: {integrity: sha512-Tunf6r6m6tnZsG9GYWndg0z8dEV7fD733VBFzFJ5Vcm1FtlXB8xBD/rtrBi2a3YKEV7hHtxiZtW5EAVADoe1pA==}
     engines: {node: '>=18'}
@@ -5675,11 +5484,6 @@ packages:
 
   typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5756,6 +5560,12 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-debounce@10.0.4:
+    resolution: {integrity: sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '*'
 
   use-debounce@7.0.1:
     resolution: {integrity: sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q==}
@@ -6882,145 +6692,73 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@esbuild/aix-ppc64@0.23.1':
-    optional: true
-
   '@esbuild/aix-ppc64@0.24.0':
-    optional: true
-
-  '@esbuild/android-arm64@0.23.1':
     optional: true
 
   '@esbuild/android-arm64@0.24.0':
     optional: true
 
-  '@esbuild/android-arm@0.23.1':
-    optional: true
-
   '@esbuild/android-arm@0.24.0':
-    optional: true
-
-  '@esbuild/android-x64@0.23.1':
     optional: true
 
   '@esbuild/android-x64@0.24.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.23.1':
-    optional: true
-
   '@esbuild/darwin-arm64@0.24.0':
-    optional: true
-
-  '@esbuild/darwin-x64@0.23.1':
     optional: true
 
   '@esbuild/darwin-x64@0.24.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.23.1':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.24.0':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.23.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.24.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.23.1':
-    optional: true
-
   '@esbuild/linux-arm64@0.24.0':
-    optional: true
-
-  '@esbuild/linux-arm@0.23.1':
     optional: true
 
   '@esbuild/linux-arm@0.24.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.23.1':
-    optional: true
-
   '@esbuild/linux-ia32@0.24.0':
-    optional: true
-
-  '@esbuild/linux-loong64@0.23.1':
     optional: true
 
   '@esbuild/linux-loong64@0.24.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.23.1':
-    optional: true
-
   '@esbuild/linux-mips64el@0.24.0':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.23.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.24.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.23.1':
-    optional: true
-
   '@esbuild/linux-riscv64@0.24.0':
-    optional: true
-
-  '@esbuild/linux-s390x@0.23.1':
     optional: true
 
   '@esbuild/linux-s390x@0.24.0':
     optional: true
 
-  '@esbuild/linux-x64@0.23.1':
-    optional: true
-
   '@esbuild/linux-x64@0.24.0':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.23.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.24.0':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.23.1':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.24.0':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.24.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.23.1':
-    optional: true
-
   '@esbuild/sunos-x64@0.24.0':
-    optional: true
-
-  '@esbuild/win32-arm64@0.23.1':
     optional: true
 
   '@esbuild/win32-arm64@0.24.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.23.1':
-    optional: true
-
   '@esbuild/win32-ia32@0.24.0':
-    optional: true
-
-  '@esbuild/win32-x64@0.23.1':
     optional: true
 
   '@esbuild/win32-x64@0.24.0':
@@ -7104,7 +6842,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@hopper-ui/tokens@4.4.0': {}
+  '@hopper-ui/tokens@4.4.1': {}
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -7318,7 +7056,7 @@ snapshots:
 
   '@orbit-ui/transition-css@2.4.0':
     dependencies:
-      '@hopper-ui/tokens': 4.4.0
+      '@hopper-ui/tokens': 4.4.1
 
   '@orbit-ui/transition-icons@2.0.0': {}
 
@@ -7343,6 +7081,8 @@ snapshots:
       webpack-dev-server: 5.1.0(webpack-cli@5.1.4)(webpack@5.95.0)
 
   '@popperjs/core@2.11.2': {}
+
+  '@popperjs/core@2.11.8': {}
 
   '@react-aria/accordion@3.0.0-alpha.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8751,11 +8491,6 @@ snapshots:
     dependencies:
       '@types/react': 18.3.12
 
-  '@types/react@18.3.11':
-    dependencies:
-      '@types/prop-types': 15.7.13
-      csstype: 3.1.3
-
   '@types/react@18.3.12':
     dependencies:
       '@types/prop-types': 15.7.13
@@ -8817,24 +8552,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.6.0(eslint@8.57.1)(typescript@5.6.3)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.6.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.6.3)
-      '@typescript-eslint/visitor-keys': 7.18.0
-      eslint: 8.57.1
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      ts-api-utils: 1.4.0(typescript@5.6.3)
-    optionalDependencies:
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -8863,19 +8580,6 @@ snapshots:
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.5.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.6.0
-      '@typescript-eslint/types': 8.6.0
-      '@typescript-eslint/typescript-estree': 8.6.0(typescript@5.6.3)
-      '@typescript-eslint/visitor-keys': 8.6.0
-      debug: 4.3.7(supports-color@5.5.0)
-      eslint: 8.57.1
-    optionalDependencies:
-      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8919,18 +8623,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.6.3)
-      debug: 4.3.7(supports-color@5.5.0)
-      eslint: 8.57.1
-      ts-api-utils: 1.4.0(typescript@5.6.3)
-    optionalDependencies:
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
@@ -8963,20 +8655,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.7(supports-color@5.5.0)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.6.3
-      tsutils: 3.21.0(typescript@5.6.3)
-    optionalDependencies:
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -9003,21 +8681,6 @@ snapshots:
       ts-api-utils: 1.4.0(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@5.5.0)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 1.4.0(typescript@5.6.3)
-    optionalDependencies:
-      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9051,21 +8714,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.6.0(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.6.0
-      '@typescript-eslint/visitor-keys': 8.6.0
-      debug: 4.3.7(supports-color@5.5.0)
-      fast-glob: 3.3.2
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 1.4.0(typescript@5.6.3)
-    optionalDependencies:
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/typescript-estree@8.6.0(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/types': 8.6.0
@@ -9096,21 +8744,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.6.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
-      eslint: 8.57.1
-      eslint-scope: 5.1.1
-      semver: 7.6.3
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
@@ -9132,17 +8765,6 @@ snapshots:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.4)
-      eslint: 8.57.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.6.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -9297,32 +8919,6 @@ snapshots:
       - jest
       - supports-color
 
-  '@workleap/eslint-plugin@3.2.2(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
-      eslint-plugin-mdx: 3.1.5(eslint@8.57.1)
-      eslint-plugin-package-json: 0.10.4(eslint@8.57.1)(jsonc-eslint-parser@2.4.0)
-      eslint-plugin-react: 7.37.2(eslint@8.57.1)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
-      eslint-plugin-storybook: 0.8.0(eslint@8.57.1)(typescript@5.6.3)
-      eslint-plugin-testing-library: 6.4.0(eslint@8.57.1)(typescript@5.6.3)
-      eslint-plugin-yml: 1.15.0(eslint@8.57.1)
-      jsonc-eslint-parser: 2.4.0
-      yaml-eslint-parser: 1.2.3
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.6.0(eslint@8.57.1)(typescript@5.6.3)
-      eslint: 8.57.1
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - bluebird
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jest
-      - supports-color
-
   '@workleap/eslint-plugin@3.2.2(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
@@ -9387,6 +8983,19 @@ snapshots:
       - '@hopper-ui/styled-system'
       - react-aria-components
 
+  '@workleap/orbiter-ui@5.6.6(@hopper-ui/components@1.3.31(@hopper-ui/styled-system@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria-components@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria@3.35.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@hopper-ui/styled-system@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria-components@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@hopper-ui/components': 1.3.31(@hopper-ui/styled-system@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria-components@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria@3.35.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@hopper-ui/icons': 2.8.4(@hopper-ui/styled-system@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-aria-components@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@hopper-ui/styled-system': 2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@hopper-ui/tokens': 4.4.1
+      '@popperjs/core': 2.11.8
+      react: 18.3.1
+      react-aria-components: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      use-debounce: 10.0.4(react@18.3.1)
+
   '@workleap/swc-configs@2.2.3(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(browserslist@4.23.3)':
     dependencies:
       '@swc/core': 1.7.26(@swc/helpers@0.5.13)
@@ -9401,11 +9010,6 @@ snapshots:
     optionalDependencies:
       browserslist: 4.24.2
 
-  '@workleap/tsup-configs@3.0.6(tsup@8.3.0(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0))(typescript@5.6.3)':
-    dependencies:
-      tsup: 8.3.0(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0)
-      typescript: 5.6.3
-
   '@workleap/tsup-configs@3.0.6(tsup@8.3.5(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.7.2)(yaml@2.6.0))(typescript@5.7.2)':
     dependencies:
       tsup: 8.3.5(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.7.2)(yaml@2.6.0)
@@ -9414,10 +9018,6 @@ snapshots:
   '@workleap/typescript-configs@3.0.2(typescript@5.5.4)':
     dependencies:
       typescript: 5.5.4
-
-  '@workleap/typescript-configs@3.0.2(typescript@5.6.3)':
-    dependencies:
-      typescript: 5.6.3
 
   '@workleap/typescript-configs@3.0.2(typescript@5.7.2)':
     dependencies:
@@ -9732,11 +9332,6 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.0.0
-
-  bundle-require@5.0.0(esbuild@0.23.1):
-    dependencies:
-      esbuild: 0.23.1
-      load-tsconfig: 0.2.5
 
   bundle-require@5.0.0(esbuild@0.24.0):
     dependencies:
@@ -10260,33 +9855,6 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
-  esbuild@0.23.1:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.23.1
-      '@esbuild/android-arm': 0.23.1
-      '@esbuild/android-arm64': 0.23.1
-      '@esbuild/android-x64': 0.23.1
-      '@esbuild/darwin-arm64': 0.23.1
-      '@esbuild/darwin-x64': 0.23.1
-      '@esbuild/freebsd-arm64': 0.23.1
-      '@esbuild/freebsd-x64': 0.23.1
-      '@esbuild/linux-arm': 0.23.1
-      '@esbuild/linux-arm64': 0.23.1
-      '@esbuild/linux-ia32': 0.23.1
-      '@esbuild/linux-loong64': 0.23.1
-      '@esbuild/linux-mips64el': 0.23.1
-      '@esbuild/linux-ppc64': 0.23.1
-      '@esbuild/linux-riscv64': 0.23.1
-      '@esbuild/linux-s390x': 0.23.1
-      '@esbuild/linux-x64': 0.23.1
-      '@esbuild/netbsd-x64': 0.23.1
-      '@esbuild/openbsd-arm64': 0.23.1
-      '@esbuild/openbsd-x64': 0.23.1
-      '@esbuild/sunos-x64': 0.23.1
-      '@esbuild/win32-arm64': 0.23.1
-      '@esbuild/win32-ia32': 0.23.1
-      '@esbuild/win32-x64': 0.23.1
-
   esbuild@0.24.0:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.24.0
@@ -10364,16 +9932,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.6.0(eslint@8.57.1)(typescript@5.6.3)
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -10408,35 +9966,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.6.0(eslint@8.57.1)(typescript@5.5.4)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
-      hasown: 2.0.2
-      is-core-module: 2.15.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.8
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.6.0(eslint@8.57.1)(typescript@5.6.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -10477,16 +10006,6 @@ snapshots:
       eslint: 8.57.1
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3):
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.6.3)
-      eslint: 8.57.1
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10607,17 +10126,6 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-storybook@0.8.0(eslint@8.57.1)(typescript@5.6.3):
-    dependencies:
-      '@storybook/csf': 0.0.1
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.6.3)
-      eslint: 8.57.1
-      requireindex: 1.2.0
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   eslint-plugin-storybook@0.8.0(eslint@8.57.1)(typescript@5.7.2):
     dependencies:
       '@storybook/csf': 0.0.1
@@ -10632,14 +10140,6 @@ snapshots:
   eslint-plugin-testing-library@6.4.0(eslint@8.57.1)(typescript@5.5.4):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      eslint: 8.57.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-testing-library@6.4.0(eslint@8.57.1)(typescript@5.6.3):
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -10753,18 +10253,6 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   events@3.3.0: {}
-
-  execa@5.1.1:
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 6.0.1
-      human-signals: 2.1.0
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
 
   express@4.21.0:
     dependencies:
@@ -10934,8 +10422,6 @@ snapshots:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.2
-
-  get-stream@6.0.1: {}
 
   get-symbol-description@1.0.2:
     dependencies:
@@ -11118,8 +10604,6 @@ snapshots:
       - debug
 
   human-id@1.0.2: {}
-
-  human-signals@2.1.0: {}
 
   hyperdyperid@1.2.0: {}
 
@@ -11304,8 +10788,6 @@ snapshots:
   is-shared-array-buffer@1.0.3:
     dependencies:
       call-bind: 1.0.7
-
-  is-stream@2.0.1: {}
 
   is-string@1.0.7:
     dependencies:
@@ -11862,8 +11344,6 @@ snapshots:
 
   mime@1.6.0: {}
 
-  mimic-fn@2.1.0: {}
-
   mini-css-extract-plugin@2.9.2(webpack@5.95.0):
     dependencies:
       schema-utils: 4.2.0
@@ -11974,10 +11454,6 @@ snapshots:
       npm-package-arg: 11.0.3
       semver: 7.6.3
 
-  npm-run-path@4.0.1:
-    dependencies:
-      path-key: 3.1.1
-
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -12031,10 +11507,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-
-  onetime@5.1.2:
-    dependencies:
-      mimic-fn: 2.1.0
 
   open@10.1.0:
     dependencies:
@@ -12379,6 +11851,8 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   react-refresh@0.14.2: {}
 
@@ -12754,8 +12228,6 @@ snapshots:
       get-intrinsic: 1.2.4
       object-inspect: 1.13.2
 
-  signal-exit@3.0.7: {}
-
   signal-exit@4.1.0: {}
 
   simple-update-notifier@2.0.0:
@@ -12938,8 +12410,6 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-final-newline@2.0.0: {}
-
   strip-json-comments@3.1.1: {}
 
   style-loader@3.3.4(webpack@5.95.0):
@@ -13072,10 +12542,6 @@ snapshots:
     dependencies:
       typescript: 5.5.4
 
-  ts-api-utils@1.4.0(typescript@5.6.3):
-    dependencies:
-      typescript: 5.6.3
-
   ts-api-utils@1.4.0(typescript@5.7.2):
     dependencies:
       typescript: 5.7.2
@@ -13107,35 +12573,6 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
-
-  tsup@8.3.0(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0):
-    dependencies:
-      bundle-require: 5.0.0(esbuild@0.23.1)
-      cac: 6.7.14
-      chokidar: 3.6.0
-      consola: 3.2.3
-      debug: 4.3.7(supports-color@5.5.0)
-      esbuild: 0.23.1
-      execa: 5.1.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.6.0)
-      resolve-from: 5.0.0
-      rollup: 4.24.4
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyglobby: 0.2.10
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.48.0(@types/node@22.9.0)
-      '@swc/core': 1.9.3(@swc/helpers@0.5.15)
-      postcss: 8.4.47
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
 
   tsup@8.3.5(@microsoft/api-extractor@7.48.0(@types/node@22.9.0))(@swc/core@1.9.3(@swc/helpers@0.5.15))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.7.2)(yaml@2.6.0):
     dependencies:
@@ -13170,11 +12607,6 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.5.4
-
-  tsutils@3.21.0(typescript@5.6.3):
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.6.3
 
   tsutils@3.21.0(typescript@5.7.2):
     dependencies:
@@ -13232,8 +12664,6 @@ snapshots:
     optional: true
 
   typescript@5.5.4: {}
-
-  typescript@5.6.3: {}
 
   typescript@5.7.2: {}
 
@@ -13346,6 +12776,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-debounce@10.0.4(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   use-debounce@7.0.1(react@18.3.1):
     dependencies:

--- a/samples/react/src/AppContext.tsx
+++ b/samples/react/src/AppContext.tsx
@@ -1,18 +1,18 @@
 import { ThemeProvider } from "@workleap/orbiter-ui";
 import { createContext, useContext, useState, type PropsWithChildren } from "react";
 
-interface AppContextProps {
+interface WidgetsContextProps {
     theme: "light" | "dark" | "system";
     setTheme: (value: "light" | "dark" | "system") => void;}
 
 
-const AppContext = createContext<AppContextProps>({
+const AppContext = createContext<WidgetsContextProps>({
     theme: "light",
     setTheme: () => {}
 });
 
 
-export function AppContextProvider({ children }: PropsWithChildren) {
+export function WidgetsContextProvider({ children }: PropsWithChildren) {
     const [theme, setTheme] = useState< "light" | "dark" | "system">("light");
 
 

--- a/samples/react/src/Layout.tsx
+++ b/samples/react/src/Layout.tsx
@@ -24,18 +24,27 @@ export function Layout() {
                             padding: "5px"
                         }}
                     >
-
-                        <Button
-                            size="sm"
-                            variant="primary"
-                            onClick={() => {
-                                const newTheme = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
-                                document.documentElement.setAttribute("data-theme", newTheme);
-                                setTheme(newTheme);
-                                window.MovieWidgets?.update({ theme: newTheme });
-                            }}
-                        >Change Theme</Button>
+                        <Flex direction="row" gap="inline-sm">
+                            <Button
+                                size="sm"
+                                variant="primary"
+                                onClick={() => {
+                                    const newTheme = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
+                                    document.documentElement.setAttribute("data-theme", newTheme);
+                                    setTheme(newTheme);
+                                    window.MovieWidgets?.update({ theme: newTheme });
+                                }}
+                            >Change Theme</Button>
+                            <Button
+                                size="sm"
+                                variant="primary"
+                                onClick={() => {
+                                    window.MovieWidgets?.clearSelectedMovie();
+                                }}
+                            >Clear Selected Movie</Button>
+                        </Flex>
                         <SelectedMovie />
+
                     </Flex>
                 </header>
                 <main>

--- a/samples/react/src/Layout.tsx
+++ b/samples/react/src/Layout.tsx
@@ -3,13 +3,13 @@ import { Link, Outlet } from "react-router-dom";
 
 import { MovieFinder, SelectedMovie } from "@samples/movie-widgets/react";
 
-import { AppContextProvider, useAppContext } from "./AppContext.tsx";
+import { WidgetsContextProvider, useAppContext } from "./AppContext.tsx";
 
 export function Layout() {
     const { setTheme } = useAppContext();
 
     return (
-        <AppContextProvider>
+        <WidgetsContextProvider>
             <Div>
                 <header style={{ borderBottom: "1px solid black", padding: "5px", display: "flex", justifyContent: "space-between" }}>
                     <div>
@@ -52,6 +52,6 @@ export function Layout() {
                 </main>
             </Div>
             <MovieFinder />
-        </AppContextProvider>
+        </WidgetsContextProvider>
     );
 }

--- a/samples/vanilla-js/public/index.html
+++ b/samples/vanilla-js/public/index.html
@@ -20,10 +20,10 @@
         </style>
     </head>
     <body>
-        <wl-header></wl-header>
         <header style="border-bottom: 1px solid black; padding: 5px; display: flex; justify-content: space-between;">
-            <div>
+            <div style="display: flex; flex-direction: row; width:100%; justify-content: space-between;">
                 <h1>VanillaJs App</h1>
+                <div style="align-self: center;"><button id="clearSelection">Clear Selection</button></div>
             </div>
         </header>
         <div style="display: flex;">

--- a/samples/vanilla-js/public/index.js
+++ b/samples/vanilla-js/public/index.js
@@ -26,7 +26,7 @@ function addEventListenerOnChangeThemeButton() {
     const button = document.getElementById("changeTheme");
 
     button.addEventListener("click", function () {
-        const oldTheme = window.MovieWidgets?.appSettings?.theme;
+        const oldTheme = window.MovieWidgets?.settings?.theme;
         const newTheme = oldTheme === "dark" ? "light" : "dark" ;
 
         document.documentElement.setAttribute("data-theme", newTheme);

--- a/samples/vanilla-js/public/index.js
+++ b/samples/vanilla-js/public/index.js
@@ -33,6 +33,11 @@ function addEventListenerOnChangeThemeButton() {
 
         window.MovieWidgets?.update({ theme: newTheme });
     });
+
+    const clearButton = document.getElementById("clearSelection");
+    clearButton.addEventListener("click", function () {
+        window.MovieWidgets?.clearSelectedMovie();
+    });
 }
 
 

--- a/samples/widgets/movie-widgets/package.json
+++ b/samples/widgets/movie-widgets/package.json
@@ -26,21 +26,21 @@
     },
     "dependencies": {
         "@hopper-ui/icons": "^2.8.4",
-        "@hopper-ui/tokens": "4.4.0",
-        "@workleap/orbiter-ui": "5.5.0",
+        "@hopper-ui/tokens": "4.4.1",
+        "@workleap/orbiter-ui": "5.6.6",
         "@workleap/r2wc": "workspace:*",
         "react": "18.3.1",
         "react-dom": "18.3.1"
     },
     "devDependencies": {
-        "@types/react": "18.3.11",
+        "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
-        "@workleap/eslint-plugin": "3.2.2",
+        "@workleap/eslint-plugin": "3.2.3",
         "@workleap/tsup-configs": "3.0.6",
         "@workleap/typescript-configs": "3.0.2",
         "eslint": "8.57.1",
-        "tsup": "8.3.0",
-        "typescript": "5.6.3"
+        "tsup": "8.3.5",
+        "typescript": "5.7.2"
     },
     "packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903"
 }

--- a/samples/widgets/movie-widgets/src/InvokeMethodHandler.ts
+++ b/samples/widgets/movie-widgets/src/InvokeMethodHandler.ts
@@ -1,0 +1,20 @@
+
+type EventCallback<T extends unknown[]> = (...args: T) => void;
+
+export class InvokeMethodHandler<T extends unknown[]=[]> {
+    private events: EventCallback<T>[] = [];
+
+    on(callback: EventCallback<T>) {
+        this.events.push(callback);
+    }
+
+    off(callback: EventCallback<T>) {
+        if (!this.events) {return;}
+        this.events = this.events.filter(cb => cb !== callback);
+    }
+
+    emit(...args: T) {
+        if (!this.events) {return;}
+        this.events.forEach(callback => callback(...args));
+    }
+}

--- a/samples/widgets/movie-widgets/src/MovieDetails.tsx
+++ b/samples/widgets/movie-widgets/src/MovieDetails.tsx
@@ -13,7 +13,7 @@ import {
     ThemeProvider
 } from "@workleap/orbiter-ui";
 import { useEffect, useState } from "react";
-import { type MovieData, useAppContext } from "./AppContextProvider.js";
+import { type MovieData, useAppContext } from "./WidgetsContextProvider.tsx";
 
 export interface MovieDetailsProps {
     showRanking: boolean;

--- a/samples/widgets/movie-widgets/src/MovieDetails.tsx
+++ b/samples/widgets/movie-widgets/src/MovieDetails.tsx
@@ -22,7 +22,7 @@ export interface MovieDetailsProps {
 }
 
 export function MovieDetails({ showRanking, onBuy, mode = "modal" }: MovieDetailsProps) {
-    const { theme, selectedMovie, eventEmitter } = useAppContext();
+    const { theme, selectedMovie, openModalHandler } = useAppContext();
 
     const [ ticketsCount, setTicketsCount ] = useState(1);
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -40,12 +40,12 @@ export function MovieDetails({ showRanking, onBuy, mode = "modal" }: MovieDetail
             setIsModalOpen(true);
         };
 
-        eventEmitter.on("movieSelected", handleOpenModal);
+        openModalHandler.on(handleOpenModal);
 
         return () => {
-            eventEmitter.off("movieSelected", handleOpenModal);
+            openModalHandler.off(handleOpenModal);
         };
-    }, [eventEmitter]);
+    }, [openModalHandler]);
 
     const content = <Content>
         <Paragraph>

--- a/samples/widgets/movie-widgets/src/MovieFinder.tsx
+++ b/samples/widgets/movie-widgets/src/MovieFinder.tsx
@@ -7,7 +7,7 @@ import {
     TextInput
 } from "@workleap/orbiter-ui";
 import { useState } from "react";
-import { type MovieData, useAppContext } from "./AppContextProvider.js";
+import { type MovieData, useAppContext } from "./WidgetsContextProvider.tsx";
 
 
 const movies : MovieData[] = [

--- a/samples/widgets/movie-widgets/src/MovieFinder.tsx
+++ b/samples/widgets/movie-widgets/src/MovieFinder.tsx
@@ -29,7 +29,7 @@ const movies : MovieData[] = [
 ];
 
 export function MovieFinder() {
-    const { isMovieFinderOpen, setIsMovieFinderOpen, setSelectedMovie, eventEmitter } = useAppContext();
+    const { isMovieFinderOpen, setIsMovieFinderOpen, setSelectedMovie, openModalHandler } = useAppContext();
     const [search, setSearch] = useState("");
 
 
@@ -42,7 +42,7 @@ export function MovieFinder() {
                 return;
             }
             setSelectedMovie(movies.find(movie => movie.key === key) ?? null);
-            eventEmitter.emit("movieSelected", key);
+            openModalHandler.emit(key);
         }
         setIsMovieFinderOpen(false);
     };

--- a/samples/widgets/movie-widgets/src/MoviePopup.tsx
+++ b/samples/widgets/movie-widgets/src/MoviePopup.tsx
@@ -1,6 +1,6 @@
 import { SparklesIcon } from "@hopper-ui/icons";
 import { Button, Text, ThemeProvider } from "@workleap/orbiter-ui";
-import { useAppContext } from "./AppContextProvider.js";
+import { useAppContext } from "./WidgetsContextProvider.tsx";
 
 
 export interface MoviePopupProps {

--- a/samples/widgets/movie-widgets/src/SelectedMovie.tsx
+++ b/samples/widgets/movie-widgets/src/SelectedMovie.tsx
@@ -1,6 +1,6 @@
 import { VideoCameraIcon } from "@hopper-ui/icons";
 import { Div, ThemeProvider } from "@workleap/orbiter-ui";
-import { useAppContext } from "./AppContextProvider.js";
+import { useAppContext } from "./WidgetsContextProvider.tsx";
 
 export function SelectedMovie() {
     const { selectedMovie, theme } = useAppContext();

--- a/samples/widgets/movie-widgets/src/Ticket.tsx
+++ b/samples/widgets/movie-widgets/src/Ticket.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Checkbox, Content, Field, Flex, Form, Heading, Label, TextInput, ThemeProvider } from "@workleap/orbiter-ui";
 import { useState } from "react";
-import { useAppContext } from "./AppContextProvider.js";
+import { useAppContext } from "./WidgetsContextProvider.tsx";
 
 export interface TicketProps {
     key: string;

--- a/samples/widgets/movie-widgets/src/WidgetsContextProvider.tsx
+++ b/samples/widgets/movie-widgets/src/WidgetsContextProvider.tsx
@@ -7,7 +7,7 @@ export interface MovieData {
     title: string;
 }
 
-interface AppContextProps {
+interface WidgetsContextProps {
     theme: "light" | "dark" | "system";
     isMovieFinderOpen: boolean;
     setIsMovieFinderOpen: (value: boolean) => void;
@@ -16,14 +16,14 @@ interface AppContextProps {
     openModalHandler: InvokeMethodHandler<[string?]>;
 }
 
-const AppContext = createContext<AppContextProps | null>(null);
+const AppContext = createContext<WidgetsContextProps | null>(null);
 
-export interface AppSettings {
+export interface WidgetsSettings {
     theme: "light" | "dark" | "system";
     clearSelectedMovieHandler: InvokeMethodHandler;
 }
 
-export function AppContextProvider({ children, clearSelectedMovieHandler, ...props }: PropsWithChildren<AppSettings>) {
+export function WidgetsContextProvider({ children, clearSelectedMovieHandler, ...props }: PropsWithChildren<WidgetsSettings>) {
     const [theme, setTheme] = useState(props.theme);
     const [isMovieFinderOpen, setIsMovieFinderOpen] = useState<boolean>(false);
     const [selectedMovie, setSelectedMovie] = useState<MovieData | null>(null);
@@ -57,7 +57,7 @@ export function AppContextProvider({ children, clearSelectedMovieHandler, ...pro
 export function useAppContext() {
     const context = useContext(AppContext);
     if (context === null) {
-        throw new Error("useAppContext must be used within a AppContextProvider");
+        throw new Error("useAppContext must be used within a WidgetsContextProvider");
     }
 
     return context;

--- a/samples/widgets/movie-widgets/src/helpers/react/index.ts
+++ b/samples/widgets/movie-widgets/src/helpers/react/index.ts
@@ -4,7 +4,6 @@ import type { MoviePopupProps } from "../../MoviePopup.js";
 import type { TicketProps } from "../../Ticket.js";
 
 export type * from "../../types.js";
-export type * from "./types.js";
 
 export const MovieDetails = createWebComponent<MovieDetailsProps>("wl-movie-details");
 export const Ticket = createWebComponent<TicketProps>("wl-ticket");

--- a/samples/widgets/movie-widgets/src/types.d.ts
+++ b/samples/widgets/movie-widgets/src/types.d.ts
@@ -1,8 +1,14 @@
 import type { IWidgetsManager } from "@workleap/r2wc";
-import type { AppSettings } from "./AppContextProvider.js";
+import type { AppSettings } from "./AppContextProvider.tsx";
+
+interface Extensions {
+    clearSelectedMovie: ()=> void;
+}
+
 
 export declare global {
     interface Window {
-        MovieWidgets?: IWidgetsManager<AppSettings>;
+        MovieWidgets?: IWidgetsManager<AppSettings> & Extensions;
     }
 }
+

--- a/samples/widgets/movie-widgets/src/types.d.ts
+++ b/samples/widgets/movie-widgets/src/types.d.ts
@@ -1,5 +1,5 @@
 import type { IWidgetsManager } from "@workleap/r2wc";
-import type { AppSettings } from "./AppContextProvider.tsx";
+import type { WidgetsSettings } from "./WidgetsContextProvider.tsx";
 
 interface Extensions {
     clearSelectedMovie: ()=> void;
@@ -8,7 +8,7 @@ interface Extensions {
 
 export declare global {
     interface Window {
-        MovieWidgets?: IWidgetsManager<AppSettings> & Extensions;
+        MovieWidgets?: IWidgetsManager<WidgetsSettings> & Extensions;
     }
 }
 

--- a/samples/widgets/movie-widgets/src/widgets.ts
+++ b/samples/widgets/movie-widgets/src/widgets.ts
@@ -1,14 +1,22 @@
 import { WidgetsManager } from "@workleap/r2wc";
 import { AppContextProvider } from "./AppContextProvider.js";
+import { InvokeMethodHandler } from "./InvokeMethodHandler.ts";
 import { MovieDetailsElement } from "./MovieDetailsElement.js";
 import { MovieFinderElement } from "./MovieFinderElement.js";
 import { MoviePopUpElement } from "./MoviePopUpElement.js";
 import { SelectedMovieElement } from "./SelectedMovieElement.js";
 import { TicketElement } from "./TicketElement.js";
 
+const clearSelectedMovieHandler = new InvokeMethodHandler();
+
 const MovieWidgets = new WidgetsManager({
     elements: [MovieDetailsElement, MoviePopUpElement, MovieFinderElement, SelectedMovieElement, TicketElement],
-    contextProvider: AppContextProvider
+    contextProvider: AppContextProvider,
+    contextProviderProps:  {
+        clearSelectedMovieHandler
+    }
+}).extends({
+    clearSelectedMovie: clearSelectedMovieHandler.emit.bind(clearSelectedMovieHandler)
 });
 
 window.MovieWidgets = MovieWidgets;

--- a/samples/widgets/movie-widgets/src/widgets.ts
+++ b/samples/widgets/movie-widgets/src/widgets.ts
@@ -1,17 +1,17 @@
 import { WidgetsManager } from "@workleap/r2wc";
-import { AppContextProvider } from "./AppContextProvider.js";
 import { InvokeMethodHandler } from "./InvokeMethodHandler.ts";
 import { MovieDetailsElement } from "./MovieDetailsElement.js";
 import { MovieFinderElement } from "./MovieFinderElement.js";
 import { MoviePopUpElement } from "./MoviePopUpElement.js";
 import { SelectedMovieElement } from "./SelectedMovieElement.js";
 import { TicketElement } from "./TicketElement.js";
+import { WidgetsContextProvider } from "./WidgetsContextProvider.tsx";
 
 const clearSelectedMovieHandler = new InvokeMethodHandler();
 
 const MovieWidgets = new WidgetsManager({
     elements: [MovieDetailsElement, MoviePopUpElement, MovieFinderElement, SelectedMovieElement, TicketElement],
-    contextProvider: AppContextProvider,
+    contextProvider: WidgetsContextProvider,
     contextProviderProps:  {
         clearSelectedMovieHandler
     }


### PR DESCRIPTION
- Add `contextProviderProps` and `extends` method to `WidgetsManager` to make it more flexible and being able to expose functions outside of the Widgets.
- Rename the `appSettings` to `settings` in `IWidgetsManager` interface. 
- Do some renames: `App` -> `Widgets` and `Config` -> `Settings`