### PR TITLE
fix wrong render call

### DIFF
--- a/.changeset/pretty-dryers-double.md
+++ b/.changeset/pretty-dryers-double.md
@@ -1,0 +1,5 @@
+---
+"@workleap/r2wc": patch
+---
+
+Fix the wrong render() call when a widget is removed removed, unmount() is called, and then a new widget gets mounted all on a same thread.


### PR DESCRIPTION
 In rare cases, the initialized flag may be changed to false before the render is called. It is the case:

1. A widget is removed from the page while the widgets manager is initialized. So, the render is enqueued.
2. But, during the same thread an "unmount" is requested to the widgets manager. This makes the initialized flag false.
3. Then, a new widget is getting added to the page while the widgets manager is not initialized yet.
4. everything on the thread is done and now the enqueued render is called as scheduled.
5. if we don't check the initialized flag here, the render will be called and unknown error may occur.

Real example: the above example occurs on Storybooks when navigating between stories and when you call unmount() between stories.
