### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/packages/r2wc/CHANGELOG.md
+++ b/packages/r2wc/CHANGELOG.md
@@ -4,41 +4,41 @@
 
 ### Patch Changes
 
-- [#24](https://github.com/gsoft-inc/wl-r2wc/pull/24) [`1cea5a7`](https://github.com/gsoft-inc/wl-r2wc/commit/1cea5a7132919be0d159dc2de676d78b247eaf6e) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fix peer dependencies released with 1.2.2.
+- [#24](https://github.com/workleap/wl-r2wc/pull/24) [`1cea5a7`](https://github.com/workleap/wl-r2wc/commit/1cea5a7132919be0d159dc2de676d78b247eaf6e) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fix peer dependencies released with 1.2.2.
 
 ## 1.2.2
 
 ### Patch Changes
 
-- [#22](https://github.com/gsoft-inc/wl-r2wc/pull/22) [`effbeb0`](https://github.com/gsoft-inc/wl-r2wc/commit/effbeb07cb02a2817854bf0ef0df18e8b94de066) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Move react deps to peer dependencies.
+- [#22](https://github.com/workleap/wl-r2wc/pull/22) [`effbeb0`](https://github.com/workleap/wl-r2wc/commit/effbeb07cb02a2817854bf0ef0df18e8b94de066) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Move react deps to peer dependencies.
 
 ## 1.2.1
 
 ### Patch Changes
 
-- [#20](https://github.com/gsoft-inc/wl-r2wc/pull/20) [`64baf52`](https://github.com/gsoft-inc/wl-r2wc/commit/64baf528204dcbe2454dba9c3669391b6be76cfd) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - Fix the wrong render() call when a widget is removed removed, unmount() is called, and then a new widget gets mounted all on a same thread.
+- [#20](https://github.com/workleap/wl-r2wc/pull/20) [`64baf52`](https://github.com/workleap/wl-r2wc/commit/64baf528204dcbe2454dba9c3669391b6be76cfd) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - Fix the wrong render() call when a widget is removed removed, unmount() is called, and then a new widget gets mounted all on a same thread.
 
 ## 1.2.0
 
 ### Minor Changes
 
-- [#18](https://github.com/gsoft-inc/wl-r2wc/pull/18) [`c0df5ec`](https://github.com/gsoft-inc/wl-r2wc/commit/c0df5ec85e796f305de8835114fbf4af12373773) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - - Add `contextProviderProps` and `extends` method to `WidgetsManager` to make it more flexible and being able to expose functions outside of the Widgets.
+- [#18](https://github.com/workleap/wl-r2wc/pull/18) [`c0df5ec`](https://github.com/workleap/wl-r2wc/commit/c0df5ec85e796f305de8835114fbf4af12373773) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - - Add `contextProviderProps` and `extends` method to `WidgetsManager` to make it more flexible and being able to expose functions outside of the Widgets.
   - Rename the `appSettings` to `settings` in `IWidgetsManager` interface.
 
 ## 1.1.1
 
 ### Patch Changes
 
-- [#16](https://github.com/gsoft-inc/wl-r2wc/pull/16) [`1154b06`](https://github.com/gsoft-inc/wl-r2wc/commit/1154b06d52d24ab307305787d5698dff67e8d1fd) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - Fix a bug: Resolve web elements "data" properties even if they have been set sooner than the element gets defined.
+- [#16](https://github.com/workleap/wl-r2wc/pull/16) [`1154b06`](https://github.com/workleap/wl-r2wc/commit/1154b06d52d24ab307305787d5698dff67e8d1fd) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - Fix a bug: Resolve web elements "data" properties even if they have been set sooner than the element gets defined.
 
 ## 1.1.0
 
 ### Minor Changes
 
-- [#14](https://github.com/gsoft-inc/wl-r2wc/pull/14) [`99698b3`](https://github.com/gsoft-inc/wl-r2wc/commit/99698b38daf8d4834dc68de5d3d50aa1aafa3fa9) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - Add unmount function to unlock calling initialize again(for testing purposes)
+- [#14](https://github.com/workleap/wl-r2wc/pull/14) [`99698b3`](https://github.com/workleap/wl-r2wc/commit/99698b38daf8d4834dc68de5d3d50aa1aafa3fa9) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - Add unmount function to unlock calling initialize again(for testing purposes)
 
 ## 1.0.0
 
 ### Major Changes
 
-- [`db4e325`](https://github.com/gsoft-inc/wl-r2wc/commit/db4e32527c553a95d6d7a64e754e44acb8d98ceb) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - initial r2wc package
+- [`db4e325`](https://github.com/workleap/wl-r2wc/commit/db4e32527c553a95d6d7a64e754e44acb8d98ceb) Thanks [@mahmoudmoravej](https://github.com/mahmoudmoravej)! - initial r2wc package

--- a/packages/r2wc/package.json
+++ b/packages/r2wc/package.json
@@ -4,7 +4,7 @@
     "author": "Workleap",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-r2wc.git"
+        "url": "git+https://github.com/workleap/wl-r2wc.git"
     },
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 